### PR TITLE
Fix restart overlay not closing and resetting player position

### DIFF
--- a/javascript.js
+++ b/javascript.js
@@ -349,19 +349,30 @@ class Game {
   }
 
   resetLevel() {
-    if (this.checkpoint && this.checkpoint.reached) {
+    const fromOverlay = this.overlay.style.visibility === 'visible';
+    this.overlay.style.visibility = 'hidden';
+
+    if (!fromOverlay && this.checkpoint && this.checkpoint.reached) {
       this.player.x = this.respawnX;
       this.player.y = this.respawnY;
     } else {
       this.player = new Player();
+      this.cameraX = 0;
       this.bullets.length = 0;
-      this.score = Math.max(0, this.score - 200);
+      if (this.checkpoint) this.checkpoint.reached = false;
+      if (!fromOverlay) {
+        this.score = Math.max(0, this.score - 200);
+      }
       this.startTime = performance.now();
     }
   }
 
   nextLevel() {
+    this.overlay.style.visibility = 'hidden';
     this.level++;
+    this.player = new Player();
+    this.cameraX = 0;
+    this.bullets.length = 0;
     this.score += Math.floor(this.level * 50);
     this.startTime = performance.now();
     this.lastTime = this.startTime;


### PR DESCRIPTION
## Summary
- Reset player, camera, and bullets when restarting or advancing to the next level
- Hide overlay after restart or next level actions
- Preserve checkpoint-based respawn only when not initiated from overlay

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check javascript.js`


------
https://chatgpt.com/codex/tasks/task_e_68948988e6fc832a9317133af3fa06af