### PR TITLE
Fix restart screen so restart resets level

### DIFF
--- a/javascript.js
+++ b/javascript.js
@@ -311,7 +311,7 @@ class Game {
   }
 
   bindButtons() {
-    document.getElementById('btn-restart').onclick = this.resetLevel.bind(this);
+    document.getElementById('btn-restart').onclick = this.restartLevel.bind(this);
     document.getElementById('btn-next').onclick    = this.nextLevel.bind(this);
     document.getElementById('btn-quit').onclick    = () => location.reload();
   }
@@ -364,6 +364,17 @@ class Game {
       this.score = Math.max(0, this.score - 200);
       this.startTime = performance.now();
     }
+  }
+
+  restartLevel() {
+    this.overlay.style.visibility = 'hidden';
+    this.player = new Player();
+    this.bullets.length = 0;
+    this.cameraX = 0;
+    this.startTime = performance.now();
+    this.lastTime = this.startTime;
+    this.checkpoint = null;
+    this.initLevel();
   }
 
   nextLevel() {


### PR DESCRIPTION
## Summary
- Ensure restart button closes overlay and restarts current level from the beginning
- Add dedicated `restartLevel` method and update button binding

## Testing
- `node --check javascript.js`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68948c057e38832a9ba45edd994b20c9